### PR TITLE
feat: ErrorResponse와 Exception Handler를 추가한다.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - setting/*
 
 # 권한 설정
 permissions:

--- a/src/main/java/com/dnd/accompany/domain/example/api/ExampleController.java
+++ b/src/main/java/com/dnd/accompany/domain/example/api/ExampleController.java
@@ -1,6 +1,7 @@
 package com.dnd.accompany.domain.example.api;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.dnd.accompany.domain.example.api.dto.CreateExampleRequest;
 import com.dnd.accompany.domain.example.api.dto.CreateExampleResponse;
 import com.dnd.accompany.domain.example.service.ExampleService;
+import com.dnd.accompany.global.common.exception.NotFoundException;
+import com.dnd.accompany.global.common.response.ErrorCode;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +28,10 @@ public class ExampleController {
 		CreateExampleResponse response = exampleService.create(request);
 
 		return ResponseEntity.ok(response.id());
+	}
+
+	@GetMapping
+	public void exception() {
+		throw new NotFoundException(ErrorCode.BAD_REQUEST);
 	}
 }

--- a/src/main/java/com/dnd/accompany/global/common/exception/BadRequestException.java
+++ b/src/main/java/com/dnd/accompany/global/common/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.dnd.accompany.global.common.exception;
+
+import com.dnd.accompany.global.common.response.ErrorCode;
+
+public class BadRequestException extends BusinessException {
+	public BadRequestException(final ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/dnd/accompany/global/common/exception/BusinessException.java
+++ b/src/main/java/com/dnd/accompany/global/common/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package com.dnd.accompany.global.common.exception;
+
+import com.dnd.accompany.global.common.response.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/dnd/accompany/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dnd/accompany/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package com.dnd.accompany.global.common.exception;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.dnd.accompany.global.common.response.ErrorCode;
+import com.dnd.accompany.global.common.response.ErrorResponse;
+import com.dnd.accompany.global.common.response.MatripConstant;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	private static final String EXCEPTION_FORMAT = "[EXCEPTION]                   -----> ";
+	private static final String EXCEPTION_MESSAGE_FORMAT = "[EXCEPTION] EXCEPTION_MESSAGE -----> [{}]";
+	private static final String EXCEPTION_TYPE_FORMAT = "[EXCEPTION] EXCEPTION_TYPE    -----> [{}]";
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(
+		final BusinessException exception
+	) {
+
+		return ResponseEntity
+			.status(exception.getErrorCode().getStatus().intValue())
+			.body(ErrorResponse.from(exception.getErrorCode()));
+	}
+
+	@ExceptionHandler(value = {MethodArgumentNotValidException.class, IllegalArgumentException.class})
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+		final MethodArgumentNotValidException exception
+	) {
+		List<FieldError> fieldErrors = exception.getBindingResult().getFieldErrors();
+		String messages = fieldErrors.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.collect(Collectors.joining("\n"));
+
+		logWarn(exception);
+		ErrorResponse.from(ErrorCode.BAD_REQUEST);
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.from(ErrorCode.BAD_REQUEST, messages));
+	}
+
+	@ExceptionHandler(value = {Exception.class, RuntimeException.class, SQLException.class})
+	public ResponseEntity<ErrorResponse> handleInternalException(
+		final Exception exception
+	) {
+		logError(exception);
+
+		return ResponseEntity
+			.status(MatripConstant.INTERNAL_SERVER_ERROR)
+			.body(ErrorResponse.from(ErrorCode.INTERNAL_SERVER));
+	}
+
+	private void logError(Exception e) {
+		log.error(EXCEPTION_TYPE_FORMAT, e.getClass().getSimpleName());
+		log.error(EXCEPTION_MESSAGE_FORMAT, e.getMessage());
+		log.error(EXCEPTION_FORMAT, e);
+	}
+
+	private void logWarn(Exception e) {
+		log.warn(EXCEPTION_TYPE_FORMAT, e.getClass().getSimpleName());
+		log.warn(EXCEPTION_MESSAGE_FORMAT, e.getMessage());
+	}
+}

--- a/src/main/java/com/dnd/accompany/global/common/exception/NotFoundException.java
+++ b/src/main/java/com/dnd/accompany/global/common/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.dnd.accompany.global.common.exception;
+
+import com.dnd.accompany.global.common.response.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+	public NotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/dnd/accompany/global/common/response/ErrorCode.java
+++ b/src/main/java/com/dnd/accompany/global/common/response/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.dnd.accompany.global.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	BAD_REQUEST(MatripConstant.BAD_REQUEST, "GLOBAL-400", "잘못된 요청입니다."),
+	ACCESS_DENIED(MatripConstant.FORBIDDEN, "GLOBAL-403", "접근 권한이 없습니다."),
+	INTERNAL_SERVER(MatripConstant.INTERNAL_SERVER_ERROR, "GLOBAL-500", "서버 내부 오류입니다."),
+
+	// ---- 유저 ---- //
+	USER_NOT_FOUND(MatripConstant.NOT_FOUND, "USER-001", "존재하지 않는 회원입니다.");
+
+	private final Integer status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/dnd/accompany/global/common/response/ErrorResponse.java
+++ b/src/main/java/com/dnd/accompany/global/common/response/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.dnd.accompany.global.common.response;
+
+import lombok.Builder;
+
+@Builder
+public record ErrorResponse(Integer status, String code, String message) {
+	public static ErrorResponse from(ErrorCode errorCode) {
+		return ErrorResponse.builder()
+			.status(errorCode.getStatus())
+			.code(errorCode.getCode())
+			.message(errorCode.getMessage())
+			.build();
+	}
+
+	public static ErrorResponse from(ErrorCode errorCode, String message) {
+		return ErrorResponse.builder()
+			.status(errorCode.getStatus())
+			.code(errorCode.getCode())
+			.message(message)
+			.build();
+	}
+}

--- a/src/main/java/com/dnd/accompany/global/common/response/MatripConstant.java
+++ b/src/main/java/com/dnd/accompany/global/common/response/MatripConstant.java
@@ -1,0 +1,31 @@
+package com.dnd.accompany.global.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public class MatripConstant {
+
+	/**
+	 * 인증/인가 자체가 유효하지 않은 경우 사용합니다.
+	 */
+	public static Integer UNAUTHORIZED = HttpStatus.UNAUTHORIZED.value();
+
+	/**
+	 * 인증 자체는 성공적이나, 권한이 존재하지 않는 경우 사용합니다.
+	 */
+	public static Integer FORBIDDEN = HttpStatus.FORBIDDEN.value();
+
+	/**
+	 * 유저의 요청이 정상적이지 않은 경우 사용합니다.
+	 */
+	public static Integer BAD_REQUEST = HttpStatus.BAD_REQUEST.value();
+
+	/**
+	 * 명령을 처리할 개체가 존재하지 않는 경우 사용합니다.
+	 */
+	public static Integer NOT_FOUND = HttpStatus.NOT_FOUND.value();
+
+	/**
+	 * 서버가 기절했을때 사용합니다.
+	 */
+	public static Integer INTERNAL_SERVER_ERROR = HttpStatus.INTERNAL_SERVER_ERROR.value();
+}


### PR DESCRIPTION
## 📄 변경 사항
- 전역적으로 예외를 처리하는  Exception Handler를 추가합니다.
- Business Exception을 추가합니다.
  - 커스텀 예외를 던질 때, 이 클래스를 상속해서 사용합니다.
- 예외 응답 객체를 추가합니다. (정상 응답의 경우 ResponseEntity를 사용합니다)



