### PR TITLE
feat: Image upload/delete api를 구현한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // NCP S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dnd/accompany/domain/image/api/ImageController.java
+++ b/src/main/java/com/dnd/accompany/domain/image/api/ImageController.java
@@ -1,0 +1,38 @@
+package com.dnd.accompany.domain.image.api;
+
+import com.dnd.accompany.domain.image.dto.ImageDeleteRequest;
+import com.dnd.accompany.domain.image.dto.ImageResponse;
+import com.dnd.accompany.domain.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @Operation(summary = "이미지 업로드")
+    @PostMapping(consumes = {MULTIPART_FORM_DATA_VALUE, APPLICATION_JSON_VALUE})
+    public ImageResponse upload(@RequestPart("file") MultipartFile multipartFile) {
+        ImageResponse response = imageService.upload(multipartFile);
+        return response;
+    }
+
+    @Operation(summary = "이미지 삭제 API")
+    @DeleteMapping(consumes = APPLICATION_JSON_VALUE)
+    public void remove(@RequestBody ImageDeleteRequest deleteRequest) {
+        imageService.remove(deleteRequest);
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/image/dto/ImageDeleteRequest.java
+++ b/src/main/java/com/dnd/accompany/domain/image/dto/ImageDeleteRequest.java
@@ -1,0 +1,17 @@
+package com.dnd.accompany.domain.image.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageDeleteRequest {
+    @NotBlank
+    private String key;
+
+    @NotBlank
+    private String path;
+}

--- a/src/main/java/com/dnd/accompany/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/dnd/accompany/domain/image/dto/ImageResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.accompany.domain.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageResponse {
+    private final String key;
+    private final String path;
+}

--- a/src/main/java/com/dnd/accompany/domain/image/exception/FileIOException.java
+++ b/src/main/java/com/dnd/accompany/domain/image/exception/FileIOException.java
@@ -1,0 +1,11 @@
+package com.dnd.accompany.domain.image.exception;
+
+
+import com.dnd.accompany.global.common.exception.BusinessException;
+import com.dnd.accompany.global.common.response.ErrorCode;
+
+public class FileIOException extends BusinessException {
+    public FileIOException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/image/exception/ImageNotExistsException.java
+++ b/src/main/java/com/dnd/accompany/domain/image/exception/ImageNotExistsException.java
@@ -1,0 +1,10 @@
+package com.dnd.accompany.domain.image.exception;
+
+import com.dnd.accompany.global.common.exception.BusinessException;
+import com.dnd.accompany.global.common.response.ErrorCode;
+
+public class ImageNotExistsException extends BusinessException {
+    public ImageNotExistsException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/image/handler/ImageStorageHandler.java
+++ b/src/main/java/com/dnd/accompany/domain/image/handler/ImageStorageHandler.java
@@ -1,0 +1,14 @@
+package com.dnd.accompany.domain.image.handler;
+
+import com.dnd.accompany.domain.image.dto.ImageResponse;
+
+import java.io.File;
+
+public interface ImageStorageHandler {
+
+    ImageResponse upload(File file);
+
+    void remove(String key);
+
+    boolean doesObjectExists(String key);
+}

--- a/src/main/java/com/dnd/accompany/domain/image/handler/NcpStorageHandler.java
+++ b/src/main/java/com/dnd/accompany/domain/image/handler/NcpStorageHandler.java
@@ -1,0 +1,61 @@
+package com.dnd.accompany.domain.image.handler;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.dnd.accompany.domain.image.dto.ImageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class NcpStorageHandler implements ImageStorageHandler{
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.ncp.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public ImageResponse upload(File file) {
+        String key = generateRandomFileName(file);
+        String path = putImage(file, key);
+        removeFile(file);
+
+        return new ImageResponse(key, path);
+    }
+
+    private void removeFile(File file) {
+        file.delete();
+    }
+
+    @Override
+    public void remove(String key) {
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, key);
+        amazonS3.deleteObject(deleteObjectRequest);
+    }
+
+    @Override
+    public boolean doesObjectExists(String key) {
+        return amazonS3.doesObjectExist(bucket, key);
+    }
+
+    private String generateRandomFileName(File file) {
+        return UUID.randomUUID().toString().substring(0, 8) + "-" + file.getName();
+    }
+
+    private String putImage(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return getImagePath(bucket, fileName);
+    }
+
+    private String getImagePath(String bucket, String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/image/service/ImageService.java
+++ b/src/main/java/com/dnd/accompany/domain/image/service/ImageService.java
@@ -1,0 +1,55 @@
+package com.dnd.accompany.domain.image.service;
+
+import com.dnd.accompany.domain.image.dto.ImageDeleteRequest;
+import com.dnd.accompany.domain.image.dto.ImageResponse;
+import com.dnd.accompany.domain.image.exception.FileIOException;
+import com.dnd.accompany.domain.image.exception.ImageNotExistsException;
+import com.dnd.accompany.domain.image.handler.ImageStorageHandler;
+import com.dnd.accompany.global.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageStorageHandler imageStorageHandler;
+
+    public ImageResponse upload(MultipartFile multipartFile) {
+        File file = convertMultipartFileToFile(multipartFile)
+               .orElseThrow();
+
+        return imageStorageHandler.upload(file);
+    }
+
+    public void remove(ImageDeleteRequest deleteRequest) {
+        if (!imageStorageHandler.doesObjectExists(deleteRequest.getKey())) {
+            throw new ImageNotExistsException(ErrorCode.IMAGE_NOT_EXISTS);
+        }
+
+        imageStorageHandler.remove(deleteRequest.getKey());
+    }
+
+    private Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) {
+        File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
+
+        try {
+            if (file.createNewFile()) {
+                try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+                    fileOutputStream.write(multipartFile.getBytes());
+                }
+                return Optional.of(file);
+            }
+
+        } catch (IOException e) {
+            throw new FileIOException(ErrorCode.FILE_IO_EXCEPTION);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/dnd/accompany/global/common/response/ErrorCode.java
+++ b/src/main/java/com/dnd/accompany/global/common/response/ErrorCode.java
@@ -32,7 +32,11 @@ public enum ErrorCode {
 
 	// ---- 동행글 ---- //
 	ACCOMPANY_BOARD_NOT_FOUND(MatripConstant.NOT_FOUND, "ACCOMPANY_BOARD-001", "동행글을 찾을 수 없습니다."),
-	ACCOMPANY_BOARD_ACCESS_DENIED(MatripConstant.FORBIDDEN, "ACCOMPANY_BOARD-002", "동행글 접근 권한이 없습니다.");
+	ACCOMPANY_BOARD_ACCESS_DENIED(MatripConstant.FORBIDDEN, "ACCOMPANY_BOARD-002", "동행글 접근 권한이 없습니다."),
+
+	// ---- 이미지 ---- //
+	IMAGE_NOT_EXISTS(MatripConstant.NOT_FOUND, "IMAGE-001", "이미지를 찾을 수 없습니다."),
+	FILE_IO_EXCEPTION(MatripConstant.INTERNAL_SERVER_ERROR, "IMAGE-002", "파일 생성에 실패했습니다.");
 
 	private final Integer status;
 	private final String code;

--- a/src/main/java/com/dnd/accompany/global/config/cloud/NcpConfig.java
+++ b/src/main/java/com/dnd/accompany/global/config/cloud/NcpConfig.java
@@ -1,0 +1,35 @@
+package com.dnd.accompany.global.config.cloud;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NcpConfig {
+    @Value("${cloud.ncp.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.ncp.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.ncp.region.static}")
+    private String region;
+
+    @Value("${cloud.ncp.s3.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/test/java/com/dnd/accompany/AccompanyApplicationTests.java
+++ b/src/test/java/com/dnd/accompany/AccompanyApplicationTests.java
@@ -3,7 +3,6 @@ package com.dnd.accompany;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class AccompanyApplicationTests {
 
     @Test


### PR DESCRIPTION
## 📄 변경 사항
- MultipartFile 타입으로 파일을 받아 NCP Storage에 업로드합니다.
  - 반환 결과로 파일의 고유한 key 와 저장 경로(path)를 반환합니다.
  - key는 파일을 삭제하는 용도로 사용됩니다(`ImageDeleteRequest`의 `String key`)
<img width="855" alt="스크린샷 2024-08-09 오전 12 29 40" src="https://github.com/user-attachments/assets/69b9f162-9ff7-41ab-b193-c08c610fd4dc">


