### PR TITLE
feat: 보낸 동행 신청서 목록 조회 시 boardId가 아니라 requestId를 반환하도록 수정한다.

### DIFF
--- a/src/main/java/com/dnd/accompany/domain/accompany/api/dto/FindBoardThumbnailsResult.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/api/dto/FindBoardThumbnailsResult.java
@@ -9,7 +9,7 @@ import java.util.List;
 import com.dnd.accompany.domain.accompany.entity.enums.Region;
 
 public record FindBoardThumbnailsResult(
-	Long boardId,
+	Long requestId,
 	String title,
 	Region region,
 	LocalDateTime startDate,

--- a/src/main/java/com/dnd/accompany/domain/accompany/api/dto/SendedAccompany.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/api/dto/SendedAccompany.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SendedAccompany {
-	private Long boardId;
+	private Long requestId;
 	private String title;
 	private Region region;
 	private LocalDateTime startDate;
@@ -22,9 +22,9 @@ public class SendedAccompany {
 	private List<String> imageUrls;
 
 	@Builder
-	public SendedAccompany(Long boardId, String title, Region region, LocalDateTime startDate, LocalDateTime endDate,
+	public SendedAccompany(Long requestId, String title, Region region, LocalDateTime startDate, LocalDateTime endDate,
         String nickname, List<String> imageUrls) {
-		this.boardId = boardId;
+		this.requestId = requestId;
 		this.title = title;
 		this.region = region;
 		this.startDate = startDate;

--- a/src/main/java/com/dnd/accompany/domain/accompany/infrastructure/querydsl/AccompanyRequestRepositoryImpl.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/infrastructure/querydsl/AccompanyRequestRepositoryImpl.java
@@ -38,7 +38,7 @@ public class AccompanyRequestRepositoryImpl implements AccompanyRequestRepositor
 	public Slice<FindBoardThumbnailsResult> findBoardThumbnails(Pageable pageable, Long applicantId) {
 		List<FindBoardThumbnailsResult> content = queryFactory
 			.select(Projections.constructor(FindBoardThumbnailsResult.class,
-				accompanyBoard.id,
+				accompanyRequest.id,
 				accompanyBoard.title,
 				accompanyBoard.region,
 				accompanyBoard.startDate,
@@ -53,7 +53,7 @@ public class AccompanyRequestRepositoryImpl implements AccompanyRequestRepositor
 			.where(isHost())
 			.where(accompanyRequest.user.id.eq(applicantId))
 			.where(accompanyRequest.requestState.eq(HOLDING))
-			.groupBy(accompanyBoard.id, accompanyBoard.title, accompanyBoard.region,
+			.groupBy(accompanyRequest.id, accompanyBoard.title, accompanyBoard.region,
 				accompanyBoard.startDate, accompanyBoard.endDate, user.nickname)
 			.orderBy(accompanyBoard.updatedAt.desc(), accompanyBoard.createdAt.desc())
 			.offset(pageable.getOffset())

--- a/src/main/java/com/dnd/accompany/domain/accompany/infrastructure/querydsl/interfaces/AccompanyRequestRepositoryCustom.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/infrastructure/querydsl/interfaces/AccompanyRequestRepositoryCustom.java
@@ -1,13 +1,9 @@
 package com.dnd.accompany.domain.accompany.infrastructure.querydsl.interfaces;
 
-import java.util.Optional;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.dnd.accompany.domain.accompany.api.dto.FindBoardThumbnailsResult;
-import com.dnd.accompany.domain.accompany.entity.AccompanyRequest;
-import com.dnd.accompany.domain.accompany.entity.enums.Role;
 
 public interface AccompanyRequestRepositoryCustom {
 	Slice<FindBoardThumbnailsResult> findBoardThumbnails(Pageable pageable, Long applicantId);

--- a/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyBoardService.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyBoardService.java
@@ -62,7 +62,7 @@ public class AccompanyBoardService {
 	private List<AccompanyBoardThumbnail> getBoardThumbnails(List<FindBoardThumbnailsResult> results) {
 		List<AccompanyBoardThumbnail> thumbnails = results.stream()
 			.map(result -> AccompanyBoardThumbnail.builder()
-				.boardId(result.boardId())
+				.boardId(result.requestId())
 				.title(result.title())
 				.region(result.region())
 				.startDate(result.startDate())

--- a/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyRequestService.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyRequestService.java
@@ -54,7 +54,7 @@ public class AccompanyRequestService {
 	private static List<SendedAccompany> getSendedAccompany(List<FindBoardThumbnailsResult> results) {
 		List<SendedAccompany> sendedAccompanies = results.stream()
 			.map(result -> SendedAccompany.builder()
-				.boardId(result.boardId())
+				.requestId(result.requestId())
 				.title(result.title())
 				.region(result.region())
 				.startDate(result.startDate())


### PR DESCRIPTION
## 📄 변경 사항
- boardId 대신 requestId를 반환하도록 수정했습니다.




