### PR TITLE
feat: 동행 신청서 조회 api의 파라미터를 변경한다.

### DIFF
--- a/src/main/java/com/dnd/accompany/domain/accompany/api/AccompanyRequestController.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/api/AccompanyRequestController.java
@@ -54,10 +54,8 @@ public class AccompanyRequestController {
 	@Operation(summary = "동행 신청서 조회")
 	@GetMapping("/{id}")
 	public ResponseEntity<ReadAccompanyResponse> read(
-		@PathVariable(name = "id") Long boardId,
-		@AuthenticationPrincipal JwtAuthentication user,
-		@Parameter(name = "applicantId", description = "조회를 요청하는 클라이언트가 게시글 작성자인 경우에만 필요합니다.", in = ParameterIn.QUERY)
-		@RequestParam(value = "applicantId", required = false) Long applicantId) {
-		return ResponseEntity.ok(accompanyServiceFacade.getRequestDetail(boardId, user.getId(), applicantId));
+		@PathVariable(name = "id") Long requestId,
+		@AuthenticationPrincipal JwtAuthentication user) {
+		return ResponseEntity.ok(accompanyServiceFacade.getRequestDetail(requestId, user.getId()));
 	}
 }

--- a/src/main/java/com/dnd/accompany/domain/accompany/api/dto/AccompanyRequestDetailInfo.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/api/dto/AccompanyRequestDetailInfo.java
@@ -8,14 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccompanyRequestDetailInfo {
-	private Long boardId;
+	private Long requestId;
 	private Long userId;
 	private String introduce;
 	private String chatLink;
 
 	@Builder
-	public AccompanyRequestDetailInfo(Long boardId, Long userId, String introduce, String chatLink) {
-		this.boardId = boardId;
+	public AccompanyRequestDetailInfo(Long requestId, Long userId, String introduce, String chatLink) {
+		this.requestId = requestId;
 		this.userId = userId;
 		this.introduce = introduce;
 		this.chatLink = chatLink;

--- a/src/main/java/com/dnd/accompany/domain/accompany/infrastructure/AccompanyRequestRepository.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/infrastructure/AccompanyRequestRepository.java
@@ -13,4 +13,10 @@ public interface AccompanyRequestRepository extends JpaRepository<AccompanyReque
 
 	@Query("SELECT r FROM AccompanyRequest r WHERE r.accompanyBoard.id = :boardId AND r.user.id = :userId")
 	Optional<AccompanyRequest> findRequestDetailInfo(Long boardId, Long userId);
+
+	@Query("SELECT r.user.id FROM AccompanyRequest r JOIN r.user WHERE r.id = :requestId")
+	Optional<Long> findUserId(Long requestId);
+
+	@Query("SELECT r.accompanyBoard.id FROM AccompanyRequest r JOIN r.accompanyBoard WHERE r.id = :requestId")
+	Optional<Long> findBoardId(Long requestId);
 }

--- a/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyRequestService.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyRequestService.java
@@ -16,9 +16,11 @@ import com.dnd.accompany.domain.accompany.api.dto.PageResponse;
 import com.dnd.accompany.domain.accompany.api.dto.SendedAccompany;
 import com.dnd.accompany.domain.accompany.entity.AccompanyBoard;
 import com.dnd.accompany.domain.accompany.entity.AccompanyRequest;
+import com.dnd.accompany.domain.accompany.exception.accompanyboard.AccompanyBoardNotFoundException;
 import com.dnd.accompany.domain.accompany.exception.accompanyrequest.AccompanyRequestNotFoundException;
 import com.dnd.accompany.domain.accompany.infrastructure.AccompanyRequestRepository;
 import com.dnd.accompany.domain.user.entity.User;
+import com.dnd.accompany.domain.user.exception.UserNotFoundException;
 import com.dnd.accompany.global.common.response.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -71,17 +73,27 @@ public class AccompanyRequestService {
 		accompanyRequestRepository.deleteByAccompanyBoardId(boardId);
 	}
 
+	@Transactional
+	public Long getApplicantId(Long requestId) {
+		return accompanyRequestRepository.findUserId(requestId)
+			.orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
+	}
 	@Transactional(readOnly = true)
 	public AccompanyRequestDetailInfo getRequestDetailInfo(Long boardId, Long userId) {
 		AccompanyRequest accompanyRequest = accompanyRequestRepository.findRequestDetailInfo(boardId, userId)
             .orElseThrow(() -> new AccompanyRequestNotFoundException(ErrorCode.ACCOMPANY_REQUEST_NOT_FOUND));
 
         return AccompanyRequestDetailInfo.builder()
-            .boardId(accompanyRequest.getAccompanyBoard().getId())
+            .requestId(accompanyRequest.getId())
 			.userId(accompanyRequest.getUser().getId())
 			.introduce(accompanyRequest.getIntroduce())
 			.chatLink(accompanyRequest.getChatLink())
 			.build();
+	}
+
+	public Long getBoardId(Long requestId){
+		return accompanyRequestRepository.findBoardId(requestId)
+			.orElseThrow(() -> new AccompanyBoardNotFoundException(ErrorCode.ACCOMPANY_BOARD_NOT_FOUND));
 	}
 
 	public AccompanyBoard getAccompanyBoard(Long boardId) {

--- a/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyServiceFacade.java
+++ b/src/main/java/com/dnd/accompany/domain/accompany/service/AccompanyServiceFacade.java
@@ -97,22 +97,24 @@ public class AccompanyServiceFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public ReadAccompanyResponse getRequestDetail(Long boardId, Long userId, Long applicantId) {
+	public ReadAccompanyResponse getRequestDetail(Long requestId, Long userId) {
+		Long boardId = accompanyRequestService.getBoardId(requestId);
 		Long hostId = accompanyUserService.getHostIdByAccompanyBoardId(boardId);
 		AccompanyBoardThumbnail boardThumbnail = getBoardThumbnail(boardId, hostId);
+
+		Long applicantId = accompanyRequestService.getApplicantId(requestId);
+		boolean isReceived = userId != applicantId;
 
 		UserProfileDetailResponse profileDetailInfo;
 		AccompanyRequestDetailInfo requestDetailInfo;
 
-		if(applicantId == null){
-			profileDetailInfo = getUserProfileDetailInfo(hostId);
-
-			requestDetailInfo = accompanyRequestService.getRequestDetailInfo(boardId, userId);
-		}
-		else{
+		if (isReceived) {
 			profileDetailInfo = getUserProfileDetailInfo(applicantId);
-			requestDetailInfo = accompanyRequestService.getRequestDetailInfo(boardId, applicantId);
+		} else {
+			profileDetailInfo = getUserProfileDetailInfo(hostId);
 		}
+
+		requestDetailInfo = accompanyRequestService.getRequestDetailInfo(boardId, applicantId);
 
 		return new ReadAccompanyResponse(boardThumbnail, profileDetailInfo, requestDetailInfo);
 	}


### PR DESCRIPTION
## 📄 변경 사항
- 동행 신청서 조회 api의 파라미터를 변경했습니다.
- boardId, applicantId를 받는 것이 아닌, 신청서 id인 requestId만 받도록 했습니다.