### PR TITLE
feat: 리뷰 상세조회 api를 구현한다.

### DIFF
--- a/src/main/java/com/dnd/accompany/domain/review/api/ReviewController.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/ReviewController.java
@@ -54,6 +54,7 @@ public class ReviewController {
     public ResponseEntity<ReviewDetailsResponse> getReviewList(
             @AuthenticationPrincipal JwtAuthentication user
     ) {
+        //TODO
         reviewService.getReviewList(user.getId());
         return null;
     }

--- a/src/main/java/com/dnd/accompany/domain/review/api/ReviewController.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/ReviewController.java
@@ -2,6 +2,8 @@ package com.dnd.accompany.domain.review.api;
 
 import com.dnd.accompany.domain.auth.dto.jwt.JwtAuthentication;
 import com.dnd.accompany.domain.review.api.dto.CreateReviewRequest;
+import com.dnd.accompany.domain.review.api.dto.ReviewDetailsResponse;
+import com.dnd.accompany.domain.review.api.dto.ReviewDetailsResult;
 import com.dnd.accompany.domain.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +35,26 @@ public class ReviewController {
         Long id = reviewService.create(user.getId(), request);
 
         return ResponseEntity.ok(id);
+    }
+
+    @Operation(summary = "리뷰 상세 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<ReviewDetailsResponse> getDetails(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("id") Long reviewId
+    ) {
+        ReviewDetailsResult result = reviewService.getReviewDetails(user.getId(), reviewId);
+        ReviewDetailsResponse response = ReviewDetailsResponse.of(result);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "받은 리뷰 목록 조회")
+    @GetMapping
+    public ResponseEntity<ReviewDetailsResponse> getReviewList(
+            @AuthenticationPrincipal JwtAuthentication user
+    ) {
+        reviewService.getReviewList(user.getId());
+        return null;
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/review/api/ReviewController.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/ReviewController.java
@@ -4,6 +4,7 @@ import com.dnd.accompany.domain.auth.dto.jwt.JwtAuthentication;
 import com.dnd.accompany.domain.review.api.dto.CreateReviewRequest;
 import com.dnd.accompany.domain.review.api.dto.ReviewDetailsResponse;
 import com.dnd.accompany.domain.review.api.dto.ReviewDetailsResult;
+import com.dnd.accompany.domain.review.api.dto.SimpleReviewResponse;
 import com.dnd.accompany.domain.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Review")
 @RestController
@@ -51,11 +54,10 @@ public class ReviewController {
 
     @Operation(summary = "받은 리뷰 목록 조회")
     @GetMapping
-    public ResponseEntity<ReviewDetailsResponse> getReviewList(
+    public ResponseEntity<List<SimpleReviewResponse>> getReviewList(
             @AuthenticationPrincipal JwtAuthentication user
     ) {
-        //TODO
-        reviewService.getReviewList(user.getId());
-        return null;
+        List<SimpleReviewResponse> responses = reviewService.getReviewList(user.getId());
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/review/api/dto/CreateReviewRequest.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/dto/CreateReviewRequest.java
@@ -1,16 +1,22 @@
 package com.dnd.accompany.domain.review.api.dto;
 
+import com.dnd.accompany.domain.review.entity.Personality;
+import com.dnd.accompany.domain.review.entity.TravelPreference;
+import com.dnd.accompany.domain.review.entity.TravelStyle;
 import com.dnd.accompany.domain.review.entity.enums.CompanionType;
 import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
 import com.dnd.accompany.domain.review.entity.enums.RecommendationStatus;
 import com.dnd.accompany.domain.review.entity.enums.SatisfactionLevel;
-import com.dnd.accompany.domain.review.entity.enums.TravelPreference;
-import com.dnd.accompany.domain.review.entity.enums.TravelStyle;
+import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
+import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record CreateReviewRequest(
+    @NotNull
+    Long receiverId,
+
     @NotNull
     Long accompanyBoardId,
 
@@ -27,10 +33,10 @@ public record CreateReviewRequest(
     List<PersonalityType> personalityType,
 
     @NotNull
-    List<TravelPreference> travelPreference,
+    List<TravelPreferenceType> travelPreference,
 
     @NotNull
-    List<TravelStyle> travelStyle,
+    List<TravelStyleType> travelStyle,
 
     String detailContent,
 

--- a/src/main/java/com/dnd/accompany/domain/review/api/dto/ReviewDetailsResponse.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/dto/ReviewDetailsResponse.java
@@ -1,0 +1,39 @@
+package com.dnd.accompany.domain.review.api.dto;
+
+import com.dnd.accompany.domain.accompany.entity.enums.Region;
+import com.dnd.accompany.domain.review.entity.enums.CompanionType;
+import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
+import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
+import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReviewDetailsResponse(
+        String writerNickname,
+        Region region,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        CompanionType companionType,
+        List<PersonalityType>personalityType,
+        List<TravelPreferenceType> travelPreference,
+        List<TravelStyleType> travelStyle,
+        String detailContent,
+        List<String> reviewImageUrls
+) {
+
+    public static ReviewDetailsResponse of(ReviewDetailsResult result) {
+        return new ReviewDetailsResponse(
+                result.getNickname(),
+                result.getRegion(),
+                result.getStartDate(),
+                result.getEndDate(),
+                result.getCompanionType(),
+                result.getPersonalityType(),
+                result.getTravelPreference(),
+                result.getTravelStyle(),
+                result.getDetailContent(),
+                result.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/review/api/dto/ReviewDetailsResult.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/dto/ReviewDetailsResult.java
@@ -1,0 +1,74 @@
+package com.dnd.accompany.domain.review.api.dto;
+
+import com.dnd.accompany.domain.accompany.entity.AccompanyBoard;
+import com.dnd.accompany.domain.accompany.entity.enums.Region;
+import com.dnd.accompany.domain.review.entity.Personality;
+import com.dnd.accompany.domain.review.entity.Review;
+import com.dnd.accompany.domain.review.entity.ReviewImage;
+import com.dnd.accompany.domain.review.entity.TravelPreference;
+import com.dnd.accompany.domain.review.entity.TravelStyle;
+import com.dnd.accompany.domain.review.entity.enums.CompanionType;
+import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
+import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
+import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
+import com.dnd.accompany.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDetailsResult {
+    private String nickname;
+    private Region region;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private CompanionType companionType;
+    private List<PersonalityType> personalityType;
+    private List<TravelPreferenceType> travelPreference;
+    private List<TravelStyleType> travelStyle;
+    private String detailContent;
+    private List<String> imageUrl;
+
+    public static ReviewDetailsResult of(User user, Review review, AccompanyBoard accompanyBoard) {
+        return new ReviewDetailsResult(
+                user.getNickname(),
+                accompanyBoard.getRegion(),
+                accompanyBoard.getStartDate(),
+                accompanyBoard.getEndDate(),
+                review.getCompanionType(),
+                toPersonalityType(review.getPersonalityType()),
+                toTravelPreferenceType(review.getTravelPreference()),
+                toTravelStyleType(review.getTravelStyle()),
+                review.getDetailContent(),
+                toImageUrl(review.getReviewImageUrls())
+        );
+    }
+
+    private static List<PersonalityType> toPersonalityType(List<Personality> personality) {
+        return personality.stream()
+                .map(Personality::getType)
+                .toList();
+    }
+
+    private static List<String> toImageUrl(List<ReviewImage> reviewImages) {
+        return reviewImages.stream()
+                .map(ReviewImage::getImageUrl)
+                .toList();
+    }
+
+    private static List<TravelPreferenceType> toTravelPreferenceType(List<TravelPreference> travelPreferences) {
+        return travelPreferences.stream()
+                .map(TravelPreference::getType)
+                .toList();
+    }
+
+    private static List<TravelStyleType> toTravelStyleType(List<TravelStyle> travelStyles) {
+        return travelStyles.stream()
+                .map(TravelStyle::getType)
+                .toList();
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/review/api/dto/SimpleReviewResponse.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/dto/SimpleReviewResponse.java
@@ -1,0 +1,17 @@
+package com.dnd.accompany.domain.review.api.dto;
+
+import com.dnd.accompany.domain.accompany.entity.enums.Region;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record SimpleReviewResponse(
+        String nickname,
+        String profileImageUrl,
+        Region region,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String detailContent
+) {
+}

--- a/src/main/java/com/dnd/accompany/domain/review/api/dto/SimpleReviewResult.java
+++ b/src/main/java/com/dnd/accompany/domain/review/api/dto/SimpleReviewResult.java
@@ -1,0 +1,20 @@
+package com.dnd.accompany.domain.review.api.dto;
+
+import com.dnd.accompany.domain.accompany.entity.enums.Region;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SimpleReviewResult {
+    private String nickname;
+    private String profileImageUrl;
+    private Region region;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String detailContent;
+}

--- a/src/main/java/com/dnd/accompany/domain/review/entity/Personality.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/Personality.java
@@ -24,7 +24,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Builder
 @Getter
 @Entity
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "review_personality")
 @SQLRestriction("deleted = false")

--- a/src/main/java/com/dnd/accompany/domain/review/entity/Personality.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/Personality.java
@@ -1,0 +1,47 @@
+package com.dnd.accompany.domain.review.entity;
+
+import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
+import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "review_personality")
+@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE review_personality SET deleted = true WHERE id = ?")
+public class Personality extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PersonalityType type;
+
+    private boolean deleted = Boolean.FALSE;
+}

--- a/src/main/java/com/dnd/accompany/domain/review/entity/Review.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/Review.java
@@ -5,18 +5,15 @@ import com.dnd.accompany.domain.review.entity.enums.CompanionType;
 import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
 import com.dnd.accompany.domain.review.entity.enums.RecommendationStatus;
 import com.dnd.accompany.domain.review.entity.enums.SatisfactionLevel;
-import com.dnd.accompany.domain.review.entity.enums.TravelPreference;
-import com.dnd.accompany.domain.review.entity.enums.TravelStyle;
-import com.dnd.accompany.domain.user.entity.enums.FoodPreference;
+import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
+import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,6 +26,7 @@ import org.hibernate.annotations.SQLRestriction;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Builder
@@ -66,47 +64,87 @@ public class Review extends TimeBaseEntity {
     @Enumerated(EnumType.STRING)
     private CompanionType companionType;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    @ElementCollection(targetClass = PersonalityType.class)
-    private List<PersonalityType> personalityType = new ArrayList<>();
+    @OneToMany(fetch = LAZY, mappedBy = "review")
+    private List<Personality> personalityType = new ArrayList<>();
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    @ElementCollection(targetClass = TravelPreference.class)
+    @OneToMany(fetch = LAZY, mappedBy = "review")
     private List<TravelPreference> travelPreference = new ArrayList<>();
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    @ElementCollection(targetClass = TravelStyle.class)
+    @OneToMany(fetch = LAZY, mappedBy = "review")
     private List<TravelStyle> travelStyle = new ArrayList<>();
 
     @Column(length = 500)
     private String detailContent;
 
-    @Column(length = 1000)
-    @ElementCollection
-    private List<String> reviewImageUrls = new ArrayList<>();
+    @OneToMany(fetch = LAZY, mappedBy = "review")
+    private List<ReviewImage> reviewImageUrls = new ArrayList<>();
 
     private boolean deleted = Boolean.FALSE;
 
-    public static Review of(Long writerId, Long receiverId, Long accompanyBoardId,
+    public static Review createReview(Long writerId, Long receiverId, Long accompanyBoardId,
                                       SatisfactionLevel satisfactionLevel, RecommendationStatus recommendationStatus,
-                                      CompanionType companionType, List<PersonalityType> personalityType,
-                                      List<TravelPreference> travelPreference, List<TravelStyle> travelStyle,
+                                      CompanionType companionType, List<PersonalityType> personalityTypes,
+                                      List<TravelPreferenceType> travelPreferences, List<TravelStyleType> travelStyles,
                                       String detailContent, List<String> reviewImageUrls) {
-        return Review.builder()
+        Review review = Review.builder()
                 .writerId(writerId)
                 .receiverId(receiverId)
                 .accompanyBoardId(accompanyBoardId)
                 .satisfactionLevel(satisfactionLevel)
                 .recommendationStatus(recommendationStatus)
                 .companionType(companionType)
-                .personalityType(personalityType)
-                .travelPreference(travelPreference)
-                .travelStyle(travelStyle)
                 .detailContent(detailContent)
-                .reviewImageUrls(reviewImageUrls)
                 .build();
+
+        review.addPersonalityTypes(personalityTypes);
+        review.addTravelPreferences(travelPreferences);
+        review.addTravelStyles(travelStyles);
+        review.addReviewImages(reviewImageUrls);
+
+        return review;
+    }
+
+    private void addPersonalityTypes(List<PersonalityType> personalityTypes) {
+        List<Personality> personalities = personalityTypes.stream()
+                .map(type -> Personality.builder()
+                        .type(type)
+                        .review(this)
+                        .build())
+                .toList();
+
+        this.personalityType.addAll(personalities);
+    }
+
+    private void addTravelPreferences(List<TravelPreferenceType> travelPreferences) {
+        List<TravelPreference> preferences = travelPreferences.stream()
+                .map(type -> TravelPreference.builder()
+                        .type(type)
+                        .review(this)
+                        .build())
+                .toList();
+
+        this.travelPreference.addAll(preferences);
+    }
+
+    private void addTravelStyles(List<TravelStyleType> travelStyles) {
+        List<TravelStyle> styles = travelStyles.stream()
+                .map(type -> TravelStyle.builder()
+                        .type(type)
+                        .review(this)
+                        .build())
+                .toList();
+
+        this.travelStyle.addAll(styles);
+    }
+
+    private void addReviewImages(List<String> reviewImageUrls) {
+        List<ReviewImage> images = reviewImageUrls.stream()
+                .map(url -> ReviewImage.builder()
+                        .imageUrl(url)
+                        .review(this)
+                        .build())
+                .toList();
+
+        this.reviewImageUrls.addAll(images);
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/review/entity/Review.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/Review.java
@@ -7,6 +7,7 @@ import com.dnd.accompany.domain.review.entity.enums.RecommendationStatus;
 import com.dnd.accompany.domain.review.entity.enums.SatisfactionLevel;
 import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
 import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -52,6 +53,9 @@ public class Review extends TimeBaseEntity {
     @Column(nullable = false)
     private Long accompanyBoardId;
 
+    @Column(length = 500)
+    private String detailContent;
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private SatisfactionLevel satisfactionLevel;
@@ -64,19 +68,16 @@ public class Review extends TimeBaseEntity {
     @Enumerated(EnumType.STRING)
     private CompanionType companionType;
 
-    @OneToMany(fetch = LAZY, mappedBy = "review")
+    @OneToMany(fetch = LAZY, mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Personality> personalityType = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "review")
+    @OneToMany(fetch = LAZY, mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravelPreference> travelPreference = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "review")
+    @OneToMany(fetch = LAZY, mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravelStyle> travelStyle = new ArrayList<>();
 
-    @Column(length = 500)
-    private String detailContent;
-
-    @OneToMany(fetch = LAZY, mappedBy = "review")
+    @OneToMany(fetch = LAZY, mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewImage> reviewImageUrls = new ArrayList<>();
 
     private boolean deleted = Boolean.FALSE;

--- a/src/main/java/com/dnd/accompany/domain/review/entity/Review.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/Review.java
@@ -46,6 +46,9 @@ public class Review extends TimeBaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    private Long receiverId;
+
+    @Column(nullable = false)
     private Long writerId;
 
     @Column(nullable = false)
@@ -87,13 +90,14 @@ public class Review extends TimeBaseEntity {
 
     private boolean deleted = Boolean.FALSE;
 
-    public static Review of(Long writerId, Long accompanyBoardId,
+    public static Review of(Long writerId, Long receiverId, Long accompanyBoardId,
                                       SatisfactionLevel satisfactionLevel, RecommendationStatus recommendationStatus,
                                       CompanionType companionType, List<PersonalityType> personalityType,
                                       List<TravelPreference> travelPreference, List<TravelStyle> travelStyle,
                                       String detailContent, List<String> reviewImageUrls) {
         return Review.builder()
                 .writerId(writerId)
+                .receiverId(receiverId)
                 .accompanyBoardId(accompanyBoardId)
                 .satisfactionLevel(satisfactionLevel)
                 .recommendationStatus(recommendationStatus)

--- a/src/main/java/com/dnd/accompany/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/ReviewImage.java
@@ -1,0 +1,46 @@
+package com.dnd.accompany.domain.review.entity;
+
+import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
+import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "review_images")
+@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE review_images SET deleted = true WHERE id = ?")
+public class ReviewImage extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    private boolean deleted = Boolean.FALSE;
+}

--- a/src/main/java/com/dnd/accompany/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/ReviewImage.java
@@ -1,11 +1,8 @@
 package com.dnd.accompany.domain.review.entity;
 
 import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
-import com.dnd.accompany.domain.review.entity.enums.PersonalityType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -24,7 +21,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Builder
 @Getter
 @Entity
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "review_images")
 @SQLRestriction("deleted = false")

--- a/src/main/java/com/dnd/accompany/domain/review/entity/TravelPreference.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/TravelPreference.java
@@ -1,0 +1,47 @@
+package com.dnd.accompany.domain.review.entity;
+
+import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
+import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "review_travel_preference")
+@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE review_travel_preference SET deleted = true WHERE id = ?")
+public class TravelPreference extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TravelPreferenceType type;
+
+    private boolean deleted = Boolean.FALSE;
+}

--- a/src/main/java/com/dnd/accompany/domain/review/entity/TravelPreference.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/TravelPreference.java
@@ -24,7 +24,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Builder
 @Getter
 @Entity
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "review_travel_preference")
 @SQLRestriction("deleted = false")

--- a/src/main/java/com/dnd/accompany/domain/review/entity/TravelStyle.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/TravelStyle.java
@@ -1,0 +1,48 @@
+package com.dnd.accompany.domain.review.entity;
+
+import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
+import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
+import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "review_travel_style")
+@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE travel_style SET deleted = true WHERE id = ?")
+public class TravelStyle extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TravelStyleType type;
+
+    private boolean deleted = Boolean.FALSE;
+}

--- a/src/main/java/com/dnd/accompany/domain/review/entity/TravelStyle.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/TravelStyle.java
@@ -1,7 +1,6 @@
 package com.dnd.accompany.domain.review.entity;
 
 import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
-import com.dnd.accompany.domain.review.entity.enums.TravelPreferenceType;
 import com.dnd.accompany.domain.review.entity.enums.TravelStyleType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,7 +24,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Builder
 @Getter
 @Entity
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "review_travel_style")
 @SQLRestriction("deleted = false")

--- a/src/main/java/com/dnd/accompany/domain/review/entity/enums/TravelPreferenceType.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/enums/TravelPreferenceType.java
@@ -3,7 +3,7 @@ package com.dnd.accompany.domain.review.entity.enums;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Travel preference", example = "PLANNED", allowableValues = {"PLANNED", "SPONTANEOUS", "PUBLIC_MONEY_CONVENIENT", "DUTCH_PAY", "DILIGENT", "RELAXED"})
-public enum TravelPreference {
+public enum TravelPreferenceType {
     PLANNED("계획적입니다"),
     SPONTANEOUS("즉흥적입니다"),
     PUBLIC_MONEY_CONVENIENT("공동 비용이 편합니다"),
@@ -13,7 +13,7 @@ public enum TravelPreference {
 
     private final String description;
 
-    TravelPreference(String description) {
+    TravelPreferenceType(String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/review/entity/enums/TravelStyleType.java
+++ b/src/main/java/com/dnd/accompany/domain/review/entity/enums/TravelStyleType.java
@@ -3,7 +3,7 @@ package com.dnd.accompany.domain.review.entity.enums;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Travel style", example = "LIKE_RESTAURANTS", allowableValues = {"LIKE_RESTAURANTS", "DOES_NOT_HAVE_TO_BE_RESTAURANT", "PREFER_HOTPLE", "LIKE_QUIET_PLACES", "LIKE_TAKING_PICTURES", "PREFER_TOURIST_DESTINATIONS", "PREFER_HEALING", "ENJOY_ACTIVITY", "LIKE_SHOPPING", "LIKE_CAFES"})
-public enum TravelStyle {
+public enum TravelStyleType {
     LIKE_RESTAURANTS("맛집을 좋아합니다"),
     DOES_NOT_HAVE_TO_BE_RESTAURANT("맛집이 아니어도 괜찮습니다"),
     PREFER_HOTPLE("핫플레이스를 선호합니다"),
@@ -17,7 +17,7 @@ public enum TravelStyle {
 
     private final String description;
 
-    TravelStyle(String description) {
+    TravelStyleType(String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/review/infrastructure/ReviewRepository.java
+++ b/src/main/java/com/dnd/accompany/domain/review/infrastructure/ReviewRepository.java
@@ -3,5 +3,5 @@ package com.dnd.accompany.domain.review.infrastructure;
 import com.dnd.accompany.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 }

--- a/src/main/java/com/dnd/accompany/domain/review/infrastructure/ReviewRepositoryCustom.java
+++ b/src/main/java/com/dnd/accompany/domain/review/infrastructure/ReviewRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.dnd.accompany.domain.review.infrastructure;
+
+import com.dnd.accompany.domain.review.api.dto.SimpleReviewResult;
+import java.util.List;
+
+public interface ReviewRepositoryCustom {
+    List<SimpleReviewResult> findAllByReceiverId(Long receiverId);
+}

--- a/src/main/java/com/dnd/accompany/domain/review/infrastructure/ReviewRepositoryImpl.java
+++ b/src/main/java/com/dnd/accompany/domain/review/infrastructure/ReviewRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.dnd.accompany.domain.review.infrastructure;
+
+import com.dnd.accompany.domain.review.api.dto.SimpleReviewResult;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.dnd.accompany.domain.accompany.entity.QAccompanyBoard.accompanyBoard;
+import static com.dnd.accompany.domain.review.entity.QReview.review;
+import static com.dnd.accompany.domain.user.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<SimpleReviewResult> findAllByReceiverId(Long receiverId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(SimpleReviewResult.class,
+                        user.nickname,
+                        user.profileImageUrl,
+                        accompanyBoard.region,
+                        accompanyBoard.startDate,
+                        accompanyBoard.endDate,
+                        review.detailContent
+                ))
+                .from(review)
+                .join(accompanyBoard)
+                    .on(review.accompanyBoardId.eq(accompanyBoard.id))
+                .join(user)
+                    .on(review.writerId.eq(user.id))
+                .where(review.receiverId.eq(receiverId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/dnd/accompany/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dnd/accompany/domain/review/service/ReviewService.java
@@ -4,6 +4,8 @@ import com.dnd.accompany.domain.accompany.entity.AccompanyBoard;
 import com.dnd.accompany.domain.accompany.infrastructure.AccompanyBoardRepository;
 import com.dnd.accompany.domain.review.api.dto.CreateReviewRequest;
 import com.dnd.accompany.domain.review.api.dto.ReviewDetailsResult;
+import com.dnd.accompany.domain.review.api.dto.SimpleReviewResponse;
+import com.dnd.accompany.domain.review.api.dto.SimpleReviewResult;
 import com.dnd.accompany.domain.review.entity.Review;
 import com.dnd.accompany.domain.review.infrastructure.ReviewRepository;
 import com.dnd.accompany.domain.user.entity.User;
@@ -14,6 +16,8 @@ import com.dnd.accompany.global.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -61,8 +65,20 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public void getReviewList(Long userId) {
-        //TODO
+    public List<SimpleReviewResponse> getReviewList(Long userId) {
+        List<SimpleReviewResult> results = reviewRepository.findAllByReceiverId(userId);
+
+        return results.stream()
+                .map(result -> SimpleReviewResponse.builder()
+                        .nickname(result.getNickname())
+                        .profileImageUrl(result.getProfileImageUrl())
+                        .detailContent(result.getDetailContent())
+                        .region(result.getRegion())
+                        .startDate(result.getStartDate())
+                        .endDate(result.getEndDate())
+                        .build()
+                )
+                .toList();
     }
 
     private Review getReview(Long reviewId) {

--- a/src/main/java/com/dnd/accompany/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dnd/accompany/domain/review/service/ReviewService.java
@@ -1,14 +1,19 @@
 package com.dnd.accompany.domain.review.service;
 
+import com.dnd.accompany.domain.accompany.entity.AccompanyBoard;
 import com.dnd.accompany.domain.accompany.infrastructure.AccompanyBoardRepository;
 import com.dnd.accompany.domain.review.api.dto.CreateReviewRequest;
+import com.dnd.accompany.domain.review.api.dto.ReviewDetailsResult;
 import com.dnd.accompany.domain.review.entity.Review;
 import com.dnd.accompany.domain.review.infrastructure.ReviewRepository;
+import com.dnd.accompany.domain.user.entity.User;
 import com.dnd.accompany.domain.user.infrastructure.UserRepository;
+import com.dnd.accompany.global.common.exception.BadRequestException;
 import com.dnd.accompany.global.common.exception.NotFoundException;
 import com.dnd.accompany.global.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,12 +23,15 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final AccompanyBoardRepository accompanyBoardRepository;
 
+    @Transactional
     public Long create(Long userId, CreateReviewRequest request) {
-        validateWriter(userId);
-        validateAccompanyBoard(request.accompanyBoardId());
+        getWriter(userId);
 
-        Review review = Review.of(
+        getAccompanyBoard(request.accompanyBoardId());
+
+        Review review = Review.createReview(
                 userId,
+                request.receiverId(),
                 request.accompanyBoardId(),
                 request.satisfactionLevel(),
                 request.recommendationStatus(),
@@ -40,13 +48,41 @@ public class ReviewService {
         return review.getId();
     }
 
-    private void validateWriter(Long userId) {
-        userRepository.findById(userId)
+    @Transactional(readOnly = true)
+    public ReviewDetailsResult getReviewDetails(Long userId, Long reviewId) {
+        Review review = getReview(reviewId);
+
+        validateReceiver(userId, review);
+
+        User writer = getWriter(review.getWriterId());
+        AccompanyBoard accompanyBoard = getAccompanyBoard(review.getAccompanyBoardId());
+
+        return ReviewDetailsResult.of(writer, review, accompanyBoard);
+    }
+
+    @Transactional(readOnly = true)
+    public void getReviewList(Long userId) {
+        //TODO
+    }
+
+    private Review getReview(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
+    }
+
+    private User getWriter(Long userId) {
+        return userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
     }
 
-    private void validateAccompanyBoard(Long accompanyBoardId) {
-        accompanyBoardRepository.findById(accompanyBoardId)
+    private AccompanyBoard getAccompanyBoard(Long accompanyBoardId) {
+        return accompanyBoardRepository.findById(accompanyBoardId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ACCOMPANY_BOARD_NOT_FOUND));
+    }
+
+    private void validateReceiver(Long userId, Review review) {
+        if (!userId.equals(review.getReceiverId())) {
+            throw new BadRequestException(ErrorCode.ACCESS_DENIED);
+        }
     }
 }

--- a/src/main/java/com/dnd/accompany/global/common/response/ErrorCode.java
+++ b/src/main/java/com/dnd/accompany/global/common/response/ErrorCode.java
@@ -40,7 +40,10 @@ public enum ErrorCode {
 
 	// ---- 이미지 ---- //
 	IMAGE_NOT_EXISTS(MatripConstant.NOT_FOUND, "IMAGE-001", "이미지를 찾을 수 없습니다."),
-	FILE_IO_EXCEPTION(MatripConstant.INTERNAL_SERVER_ERROR, "IMAGE-002", "파일 생성에 실패했습니다.");
+	FILE_IO_EXCEPTION(MatripConstant.INTERNAL_SERVER_ERROR, "IMAGE-002", "파일 생성에 실패했습니다."),
+
+	// ---- 리뷰 ---- //
+	REVIEW_NOT_FOUND(MatripConstant.NOT_FOUND, "REVIEW-001", "존재하지 않는 리뷰입니다.");
 
 	private final Integer status;
 	private final String code;


### PR DESCRIPTION
## 📄 변경 사항
- Review 엔티티 내에 존재하는 컬렉션 필드(@ElementCollection)들을 테이블로 분리합니다.
  - 테이블로 분리한 컬렉션들의 생성, 삭제는 Review 엔티티 내에서만 가능합니다. 
- Review 단건을 상세조회하는 api를 추가합니다.
- 받은 Review들을 조회하는 api도 추가합니다.

컬렉션들을 엔티티로 분리하면서 변경사항이 많아진 것 같네요.. 😭 