### PR TITLE
feat: 회원 탈퇴 api를 구현한다.

### DIFF
--- a/src/main/java/com/dnd/accompany/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dnd/accompany/domain/auth/api/AuthController.java
@@ -2,6 +2,7 @@ package com.dnd.accompany.domain.auth.api;
 
 import com.dnd.accompany.domain.auth.dto.AuthUserInfo;
 import com.dnd.accompany.domain.auth.dto.Tokens;
+import com.dnd.accompany.domain.auth.dto.jwt.JwtAuthentication;
 import com.dnd.accompany.domain.auth.oauth.dto.LoginRequest;
 import com.dnd.accompany.domain.auth.oauth.dto.OAuthUserDataResponse;
 import com.dnd.accompany.domain.auth.oauth.dto.OAuthUserInfo;
@@ -12,6 +13,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +42,15 @@ public class AuthController {
         Tokens tokens = tokenService.createTokens(authUserInfo);
 
         return ResponseEntity.ok(tokens);
+    }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Long> withdraw(@AuthenticationPrincipal JwtAuthentication user) {
+        Long userId = user.getId();
+        oAuthService.revoke(userId);
+        userService.delete(userId);
+
+        return ResponseEntity.ok(userId);
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dnd/accompany/domain/auth/api/AuthController.java
@@ -1,6 +1,7 @@
 package com.dnd.accompany.domain.auth.api;
 
 import com.dnd.accompany.domain.auth.dto.AuthUserInfo;
+import com.dnd.accompany.domain.auth.dto.DeleteUserRequest;
 import com.dnd.accompany.domain.auth.dto.Tokens;
 import com.dnd.accompany.domain.auth.dto.jwt.JwtAuthentication;
 import com.dnd.accompany.domain.auth.oauth.dto.LoginRequest;
@@ -46,10 +47,13 @@ public class AuthController {
 
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/withdraw")
-    public ResponseEntity<Long> withdraw(@AuthenticationPrincipal JwtAuthentication user) {
+    public ResponseEntity<Long> withdraw(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @RequestBody DeleteUserRequest deleteUserRequest
+    ) {
         Long userId = user.getId();
         oAuthService.revoke(userId);
-        userService.delete(userId);
+        userService.delete(userId, deleteUserRequest);
 
         return ResponseEntity.ok(userId);
     }

--- a/src/main/java/com/dnd/accompany/domain/auth/dto/DeleteUserRequest.java
+++ b/src/main/java/com/dnd/accompany/domain/auth/dto/DeleteUserRequest.java
@@ -1,0 +1,6 @@
+package com.dnd.accompany.domain.auth.dto;
+
+public record DeleteUserRequest(
+        String reason
+) {
+}

--- a/src/main/java/com/dnd/accompany/domain/auth/oauth/handler/OAuthAuthenticationHandler.java
+++ b/src/main/java/com/dnd/accompany/domain/auth/oauth/handler/OAuthAuthenticationHandler.java
@@ -8,4 +8,6 @@ public interface OAuthAuthenticationHandler {
 	OAuthProvider getAuthProvider();
 
 	OAuthUserDataResponse getOAuthUserData(OAuthUserDataRequest request);
+
+	void unlink(Long userId);
 }

--- a/src/main/java/com/dnd/accompany/domain/auth/oauth/service/OAuthService.java
+++ b/src/main/java/com/dnd/accompany/domain/auth/oauth/service/OAuthService.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.dnd.accompany.domain.user.entity.User;
+import com.dnd.accompany.domain.user.infrastructure.UserRepository;
+import com.dnd.accompany.global.common.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.dnd.accompany.domain.auth.oauth.dto.LoginRequest;
@@ -12,16 +15,20 @@ import com.dnd.accompany.domain.auth.oauth.dto.OAuthUserDataRequest;
 import com.dnd.accompany.domain.auth.oauth.dto.OAuthUserDataResponse;
 import com.dnd.accompany.domain.auth.oauth.handler.OAuthAuthenticationHandler;
 
+import static com.dnd.accompany.global.common.response.ErrorCode.USER_NOT_FOUND;
+
 @Service
 public class OAuthService {
 
 	private final Map<OAuthProvider, OAuthAuthenticationHandler> oAuthAuthenticationHandlers;
+	private final UserRepository userRepository;
 
-	public OAuthService(List<OAuthAuthenticationHandler> oAuthAuthenticationHandlers) {
+	public OAuthService(List<OAuthAuthenticationHandler> oAuthAuthenticationHandlers, UserRepository userRepository) {
 		this.oAuthAuthenticationHandlers = oAuthAuthenticationHandlers.stream().collect(
 			Collectors.toConcurrentMap(OAuthAuthenticationHandler::getAuthProvider, Function.identity())
 		);
-	}
+        this.userRepository = userRepository;
+    }
 
 	public OAuthUserDataResponse login(LoginRequest loginRequest) {
 		OAuthProvider oAuthProvider = OAuthProvider.get(loginRequest.provider());
@@ -35,7 +42,14 @@ public class OAuthService {
 		return oAuthHandler.getOAuthUserData(request);
 	}
 
-	public void revoke() {
-		// 회원 탈퇴 구현 시 추가합니다.
+	public void revoke(Long userId) {
+		User user = userRepository
+				.findById(userId)
+				.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		OAuthProvider oAuthProvider = OAuthProvider.get(user.getProvider());
+		OAuthAuthenticationHandler oAuthHandler = this.oAuthAuthenticationHandlers.get(oAuthProvider);
+
+		oAuthHandler.unlink(userId);
 	}
 }

--- a/src/main/java/com/dnd/accompany/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/accompany/domain/user/entity/User.java
@@ -1,8 +1,6 @@
 package com.dnd.accompany.domain.user.entity;
 
-import io.jsonwebtoken.lang.Assert;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 import com.dnd.accompany.domain.common.entity.TimeBaseEntity;
 
@@ -26,7 +24,6 @@ import static org.springframework.util.Assert.notNull;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("deleted = false")
 @SQLDelete(sql = "UPDATE users SET deleted = true WHERE id = ?")
 public class User extends TimeBaseEntity {
 

--- a/src/main/java/com/dnd/accompany/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/accompany/domain/user/entity/User.java
@@ -50,6 +50,8 @@ public class User extends TimeBaseEntity {
 
 	private boolean deleted = false;
 
+	private String reason;
+
 	public static User of(String nickname, String provider, String oauthId, String profileImageUrl) {
 		return User.builder()
 				.nickname(nickname)
@@ -68,5 +70,10 @@ public class User extends TimeBaseEntity {
 
 	public void addEvaluationCount(int count) {
 		this.evaluationCount += count;
+	}
+
+	public void delete(String reason) {
+		this.deleted = true;
+		this.reason = reason;
 	}
 }

--- a/src/main/java/com/dnd/accompany/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/accompany/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.dnd.accompany.domain.user.service;
 import com.dnd.accompany.domain.auth.dto.AuthUserInfo;
 import com.dnd.accompany.domain.auth.oauth.dto.OAuthUserInfo;
 import com.dnd.accompany.domain.user.entity.User;
+import com.dnd.accompany.domain.user.infrastructure.UserProfileRepository;
 import com.dnd.accompany.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
 
     @Transactional
     public AuthUserInfo getOrRegister(OAuthUserInfo oauthUserInfo) {
@@ -30,5 +32,11 @@ public class UserService {
                 oauthUserInfo.getOauthId(),
                 oauthUserInfo.getProfileImageUrl()
         ));
+    }
+
+    @Transactional
+    public void delete(Long userId) {
+        userProfileRepository.deleteById(userId);
+        userRepository.deleteById(userId);
     }
 }

--- a/src/main/java/com/dnd/accompany/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/accompany/domain/user/service/UserService.java
@@ -1,10 +1,14 @@
 package com.dnd.accompany.domain.user.service;
 
 import com.dnd.accompany.domain.auth.dto.AuthUserInfo;
+import com.dnd.accompany.domain.auth.dto.DeleteUserRequest;
 import com.dnd.accompany.domain.auth.oauth.dto.OAuthUserInfo;
 import com.dnd.accompany.domain.user.entity.User;
+import com.dnd.accompany.domain.user.entity.UserProfile;
 import com.dnd.accompany.domain.user.infrastructure.UserProfileRepository;
 import com.dnd.accompany.domain.user.infrastructure.UserRepository;
+import com.dnd.accompany.global.common.exception.NotFoundException;
+import com.dnd.accompany.global.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,8 +39,11 @@ public class UserService {
     }
 
     @Transactional
-    public void delete(Long userId) {
+    public void delete(Long userId, DeleteUserRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
         userProfileRepository.deleteById(userId);
-        userRepository.deleteById(userId);
+        user.delete(request.reason());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,9 +11,6 @@ spring:
       hibernate:
         format_sql: true
         hbm2ddl.auto: update
-  oauth2:
-    kakao:
-      host: https://kapi.kakao.com
 
 management:
   endpoints:


### PR DESCRIPTION
## 📄 변경 사항
- deleted = true인 유저도 조회할 수 있도록 `@SQLRestriction("deleted = false")` 옵션을 제거합니다.
  - reviewService 등에서 작성자 조회 시 탈퇴 회원이면 not_found_Error 발생하기 때문
- 회원 탈퇴 api를 추가합니다.



